### PR TITLE
Add MATTER_API_ENDPOINT support for matterBackend

### DIFF
--- a/charts/gravity-matter-enterprise/Chart.yaml
+++ b/charts/gravity-matter-enterprise/Chart.yaml
@@ -3,8 +3,8 @@ name: matter-ai-enterprise
 description: Helm chart to deploy Matter AI Code Review Backend for Enterprise
 type: application
 icon: https://matterai.dev/favicon.png
-appVersion: 0.1.59
-version: 0.1.19
+appVersion: 0.1.60
+version: 0.1.60
 maintainers:
-  - name: Vatsal Bajpai
-    email: vatsal@matterai.so
+  - name: MatterAI
+    email: support@matterai.so

--- a/charts/gravity-matter-enterprise/Chart.yaml
+++ b/charts/gravity-matter-enterprise/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart to deploy Matter AI Code Review Backend for Enterprise
 type: application
 icon: https://matterai.dev/favicon.png
 appVersion: 0.1.59
-version: 0.1.18
+version: 0.1.19
 maintainers:
   - name: Vatsal Bajpai
     email: vatsal@matterai.so

--- a/charts/gravity-matter-enterprise/templates/deployments.yaml
+++ b/charts/gravity-matter-enterprise/templates/deployments.yaml
@@ -44,8 +44,6 @@ spec:
               {{- if eq $key "MATTER_API_ENDPOINT" }}
               {{- if eq $componentName "matterMCP" }}
               value: "http://{{ $.Values.components.matterBackend.service.name }}.{{ $.Values.global.namespace }}.svc.cluster.local:{{ $.Values.components.matterBackend.service.port }}"
-              {{- else if eq $componentName "matterBackend" }}
-              value: "http://{{ $.Values.components.matterBackend.service.name }}.{{ $.Values.global.namespace }}.svc.cluster.local:{{ $.Values.components.matterBackend.service.port }}"
               {{- else }}
               {{- if kindIs "map" $value }}
               {{- toYaml $value | nindent 14 }}

--- a/charts/gravity-matter-enterprise/templates/deployments.yaml
+++ b/charts/gravity-matter-enterprise/templates/deployments.yaml
@@ -44,6 +44,8 @@ spec:
               {{- if eq $key "MATTER_API_ENDPOINT" }}
               {{- if eq $componentName "matterMCP" }}
               value: "http://{{ $.Values.components.matterBackend.service.name }}.{{ $.Values.global.namespace }}.svc.cluster.local:{{ $.Values.components.matterBackend.service.port }}"
+              {{- else if eq $componentName "matterBackend" }}
+              value: "http://{{ $.Values.components.matterBackend.service.name }}.{{ $.Values.global.namespace }}.svc.cluster.local:{{ $.Values.components.matterBackend.service.port }}"
               {{- else }}
               {{- if kindIs "map" $value }}
               {{- toYaml $value | nindent 14 }}

--- a/charts/gravity-matter-enterprise/values.yaml
+++ b/charts/gravity-matter-enterprise/values.yaml
@@ -41,6 +41,7 @@ components:
             secretKeyRef:
               name: postgres-matter-secrets
               key: postgres-password
+        MATTER_API_ENDPOINT: "matterai.example.com"
     service:
       name: matter-backend-service
       type: ClusterIP


### PR DESCRIPTION
## Summary
- Added MATTER_API_ENDPOINT environment variable to matterBackend component
- Modified deployment template to properly inject the environment variable for matterBackend
- Bumped chart version from 0.1.18 to 0.1.19

This change allows the matterBackend to read its own endpoint URL via the MATTER_API_ENDPOINT environment variable, which is needed for internal service communication.